### PR TITLE
Fixed event handlers in table headers in IE8

### DIFF
--- a/js/core/core.draw.js
+++ b/js/core/core.draw.js
@@ -160,7 +160,7 @@ function _fnBuildHead( oSettings )
 			}
 		}
 
-		if ( column.sTitle != cell.html() ) {
+		if ( column.sTitle != cell[0].innerHTML ) {
 			cell.html( column.sTitle );
 		}
 


### PR DESCRIPTION
On line 605, column.sTitle is set to the TH's innerHTML.
On line 1816, column.sTitle is compared with cell.html().

If you have child elements with event handlers on them inside the TH, these are not the same in IE8 (see https://gist.github.com/simonbrent/933e552739477f4be3ab#file-test-html)

As a result, the check on 1816 fails, the contents of the cell is replaced, and the event handlers are removed.

Comparing instead with cell[0].innerHTML fixes this issue.

I acknowledge that my contribution is offered under and will be made available under the project's existing license.